### PR TITLE
Enable syntax highlighting on GitHub for completions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+### Standard paths ###
+/src/_*      linguist-language=zsh
+/override/_* linguist-language=zsh
+
+### Submodules ###
+/nilsonholger_zsh-completions/_*  linguist-language=zsh
+/zchee_zsh-completions/src/*/_* linguist-language=zsh
+/zsh-users_zsh-completions/src/_* linguist-language=zsh


### PR DESCRIPTION
Using the `.gitattributes` file, we can manually set syntax highlighting for files on GitHub using the `linguist-language` variable.